### PR TITLE
Fix depleted daily limit from unspent hits

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -181,10 +181,10 @@ async def get_hits(cards_ids: List[str]) -> List[Hit]:
     return [Hit(**row) for row in rows]
 
 
-async def get_hits_today(card_id: str) -> List[Hit]:
+async def get_hits_today(card_id: str, spent: bool) -> List[Hit]:
     rows = await db.fetchall(
-        "SELECT * FROM boltcards.hits WHERE card_id = ?",
-        (card_id,),
+        "SELECT * FROM boltcards.hits WHERE card_id = ? AND spent = ?",
+        (card_id, spent,),
     )
     updatedrow = []
     for row in rows:

--- a/crud.py
+++ b/crud.py
@@ -181,10 +181,10 @@ async def get_hits(cards_ids: List[str]) -> List[Hit]:
     return [Hit(**row) for row in rows]
 
 
-async def get_hits_today(card_id: str, spent: bool) -> List[Hit]:
+async def get_hits_today(card_id: str) -> List[Hit]:
     rows = await db.fetchall(
-        "SELECT * FROM boltcards.hits WHERE card_id = ? AND spent = ?",
-        (card_id, spent,),
+        "SELECT * FROM boltcards.hits WHERE card_id = ?",
+        (card_id,),
     )
     updatedrow = []
     for row in rows:

--- a/lnurl.py
+++ b/lnurl.py
@@ -67,7 +67,7 @@ async def api_scan(p, c, request: Request, external_id: str = Query(None)):
         ip = request.headers["x-forwarded-for"]
 
     agent = request.headers["user-agent"] if "user-agent" in request.headers else ""
-    todays_hits = await get_hits_today(card.id, True)
+    todays_hits = await get_hits_today(card.id)
 
     hits_amount = 0
     for hit in todays_hits:

--- a/lnurl.py
+++ b/lnurl.py
@@ -132,7 +132,7 @@ async def lnurl_callback(
         except Exception as exc:
             return {"status": "ERROR", "reason": f"Payment failed - {exc}"}
     else:
-        return {"status": "ERROR", "reason": "Amount too high"}
+        return {"status": "ERROR", "reason": "Amount exceeds card limit"}
 
 
 # /boltcards/api/v1/auth?a=00000000000000000000000000000000

--- a/lnurl.py
+++ b/lnurl.py
@@ -67,7 +67,7 @@ async def api_scan(p, c, request: Request, external_id: str = Query(None)):
         ip = request.headers["x-forwarded-for"]
 
     agent = request.headers["user-agent"] if "user-agent" in request.headers else ""
-    todays_hits = await get_hits_today(card.id)
+    todays_hits = await get_hits_today(card.id, True)
 
     hits_amount = 0
     for hit in todays_hits:
@@ -117,18 +117,22 @@ async def lnurl_callback(
 
     card = await get_card(hit.card_id)
     assert card
-    hit = await spend_hit(id=hit.id, amount=int(invoice.amount_msat / 1000))
-    assert hit
-    try:
-        await pay_invoice(
-            wallet_id=card.wallet,
-            payment_request=pr,
-            max_sat=card.tx_limit,
-            extra={"tag": "boltcard", "hit": hit.id},
-        )
-        return {"status": "OK"}
-    except Exception as exc:
-        return {"status": "ERROR", "reason": f"Payment failed - {exc}"}
+
+    if invoice.amount_msat < card.tx_limit * 1000:
+        hit = await spend_hit(id=hit.id, amount=int(invoice.amount_msat / 1000))
+        assert hit
+        try:
+            await pay_invoice(
+                wallet_id=card.wallet,
+                payment_request=pr,
+                max_sat=card.tx_limit,
+                extra={"tag": "boltcard", "hit": hit.id},
+            )
+            return {"status": "OK"}
+        except Exception as exc:
+            return {"status": "ERROR", "reason": f"Payment failed - {exc}"}
+    else:
+        return {"status": "ERROR", "reason": "Amount too high"}
 
 
 # /boltcards/api/v1/auth?a=00000000000000000000000000000000


### PR DESCRIPTION
If an invoice payment failed (for example an over-limit payment is attempted, or just there's no route) this is still recorded as a spent hit and it may deplete the daily limit. This PR fixes it. 

Also now payment request of precisely maxWithdrawable amount doesn't pass since this is probably a PoS error or stealing, not a common payment.