### PR TITLE
add support for LUD-19 for boltcards extension

### DIFF
--- a/lnurl.py
+++ b/lnurl.py
@@ -76,13 +76,12 @@ async def api_scan(p, c, request: Request, external_id: str):
         return {"status": "ERROR", "reason": "Max daily limit spent."}
     hit = await create_hit(card.id, ip, agent, card.counter, ctr_int)
 
-    #the raw lnurl
+    # the raw lnurl
     lnurlpay_raw = str(request.url_for("boltcards.lnurlp_response", hit_id=hit.id))
-    #bech32 encoded lnurl
+    # bech32 encoded lnurl
     lnurlpay_bech32 = lnurl_encode(lnurlpay_raw)
-    #create a lud17 lnurlp to support lud19, add to payLink field of the withdrawRequest
+    # create a lud17 lnurlp to support lud19, add to payLink field of the withdrawRequest
     lnurlpay_nonbech32_lud17 = lnurlpay_raw.replace("https://", "lnurlp://").replace("http://","lnurlp://")
-
 
     return {
         "tag": "withdrawRequest",

--- a/lnurl.py
+++ b/lnurl.py
@@ -125,7 +125,7 @@ async def lnurl_callback(
             wallet_id=card.wallet,
             payment_request=pr,
             max_sat=card.tx_limit,
-            extra={"tag": "boltcard", "hit": hit.id},
+            extra={"tag": "boltcards", "hit": hit.id},
         )
         return {"status": "OK"}
     except Exception as exc:

--- a/lnurl.py
+++ b/lnurl.py
@@ -75,14 +75,23 @@ async def api_scan(p, c, request: Request, external_id: str):
     if hits_amount > card.daily_limit:
         return {"status": "ERROR", "reason": "Max daily limit spent."}
     hit = await create_hit(card.id, ip, agent, card.counter, ctr_int)
-    lnurlpay = lnurl_encode(str(request.url_for("boltcards.lnurlp_response", hit_id=hit.id)))
+
+    #the raw lnurl
+    lnurlpay_raw = str(request.url_for("boltcards.lnurlp_response", hit_id=hit.id))
+    #bech32 encoded lnurl
+    lnurlpay_bech32 = lnurl_encode(lnurlpay_raw)
+    #create a lud17 lnurlp to support lud19, add to payLink field of the withdrawRequest
+    lnurlpay_nonbech32_lud17 = lnurlpay_raw.replace("https://", "lnurlp://").replace("http://","lnurlp://")
+
+
     return {
         "tag": "withdrawRequest",
         "callback": str(request.url_for("boltcards.lnurl_callback", hit_id=hit.id)),
         "k1": hit.id,
         "minWithdrawable": 1 * 1000,
         "maxWithdrawable": card.tx_limit * 1000,
-        "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay})",
+        "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay_bech32})",
+        "payLink": lnurlpay_nonbech32_lud17, #LUD-19 compatibility
     }
 
 

--- a/lnurl.py
+++ b/lnurl.py
@@ -90,7 +90,7 @@ async def api_scan(p, c, request: Request, external_id: str):
         "minWithdrawable": 1 * 1000,
         "maxWithdrawable": card.tx_limit * 1000,
         "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay_bech32})",
-        "payLink": lnurlpay_nonbech32_lud17, #LUD-19 compatibility
+        "payLink": lnurlpay_nonbech32_lud17,  # LUD-19 compatibility
     }
 
 


### PR DESCRIPTION
LNURLw (withdrawRequest) that is returned by calling the link from bolt card now returns another field "payLink" as defined in LUD-19.

This allows compatible wallet to create e.g. refund or cashback to the card itself without need to create a separate invoice or managing another separate LNURLp or LN address.