### PR TITLE
remove uid field tooltip

### DIFF
--- a/templates/boltcards/index.html
+++ b/templates/boltcards/index.html
@@ -276,9 +276,6 @@
               type="text"
               label="Card UID "
             >
-              <q-tooltip
-                >Get from the card you'll use, using an NFC app</q-tooltip
-              >
             </q-input>
           </div>
           <div class="col-2 q-pl-sm">


### PR DESCRIPTION
the tooltip prevented pasting into the UID input field on mobile devices 