### PR TITLE
Remove the duplicate UID check as it is not needed.

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -87,7 +87,7 @@ async def get_card(card_id: str) -> Optional[Card]:
 
     return Card.parse_obj(card)
 
-
+"""
 async def get_card_by_uid(card_uid: str) -> Optional[Card]:
     row = await db.fetchone(
         "SELECT * FROM boltcards.cards WHERE uid = ?", (card_uid.upper(),)
@@ -98,7 +98,7 @@ async def get_card_by_uid(card_uid: str) -> Optional[Card]:
     card = dict(**row)
 
     return Card.parse_obj(card)
-
+"""
 
 async def get_card_by_external_id(external_id: str) -> Optional[Card]:
     row = await db.fetchone(

--- a/lnurl.py
+++ b/lnurl.py
@@ -76,13 +76,12 @@ async def api_scan(p, c, request: Request, external_id: str):
         return {"status": "ERROR", "reason": "Max daily limit spent."}
     hit = await create_hit(card.id, ip, agent, card.counter, ctr_int)
 
-    #the raw lnurl
+    # the raw lnurl
     lnurlpay_raw = str(request.url_for("boltcards.lnurlp_response", hit_id=hit.id))
-    #bech32 encoded lnurl
+    # bech32 encoded lnurl
     lnurlpay_bech32 = lnurl_encode(lnurlpay_raw)
-    #create a lud17 lnurlp to support lud19, add to payLink field of the withdrawRequest
+    # create a lud17 lnurlp to support lud19, add to payLink field of the withdrawRequest
     lnurlpay_nonbech32_lud17 = lnurlpay_raw.replace("https://", "lnurlp://").replace("http://","lnurlp://")
-
 
     return {
         "tag": "withdrawRequest",

--- a/lnurl.py
+++ b/lnurl.py
@@ -125,7 +125,7 @@ async def lnurl_callback(
             wallet_id=card.wallet,
             payment_request=pr,
             max_sat=card.tx_limit,
-            extra={"tag": "boltcard", "hit": hit.id},
+            extra={"tag": "boltcards", "hit": hit.id},
         )
         return {"status": "OK"}
     except Exception as exc:

--- a/lnurl.py
+++ b/lnurl.py
@@ -75,14 +75,23 @@ async def api_scan(p, c, request: Request, external_id: str):
     if hits_amount > card.daily_limit:
         return {"status": "ERROR", "reason": "Max daily limit spent."}
     hit = await create_hit(card.id, ip, agent, card.counter, ctr_int)
-    lnurlpay = lnurl_encode(str(request.url_for("boltcards.lnurlp_response", hit_id=hit.id)))
+
+    #the raw lnurl
+    lnurlpay_raw = str(request.url_for("boltcards.lnurlp_response", hit_id=hit.id))
+    #bech32 encoded lnurl
+    lnurlpay_bech32 = lnurl_encode(lnurlpay_raw)
+    #create a lud17 lnurlp to support lud19, add to payLink field of the withdrawRequest
+    lnurlpay_nonbech32_lud17 = lnurlpay_raw.replace("https://", "lnurlp://").replace("http://","lnurlp://")
+
+
     return {
         "tag": "withdrawRequest",
         "callback": str(request.url_for("boltcards.lnurl_callback", hit_id=hit.id)),
         "k1": hit.id,
         "minWithdrawable": 1 * 1000,
         "maxWithdrawable": card.tx_limit * 1000,
-        "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay})",
+        "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay_bech32})",
+        "payLink": lnurlpay_nonbech32_lud17, #LUD-19 compatibility
     }
 
 

--- a/lnurl.py
+++ b/lnurl.py
@@ -90,7 +90,7 @@ async def api_scan(p, c, request: Request, external_id: str):
         "minWithdrawable": 1 * 1000,
         "maxWithdrawable": card.tx_limit * 1000,
         "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay_bech32})",
-        "payLink": lnurlpay_nonbech32_lud17, #LUD-19 compatibility
+        "payLink": lnurlpay_nonbech32_lud17,  # LUD-19 compatibility
     }
 
 

--- a/migrations.py
+++ b/migrations.py
@@ -55,3 +55,10 @@ async def m001_initial(db):
         );
     """
     )
+
+async def m002_remove_constraint_unique_uid(db):
+    """
+    Do not check the duplicate UID so remove the constraint from DB.
+    """
+
+    await db.execute("ALTER TABLE boltcards.cards DROP CONSTRAINT cards_uid_key;")

--- a/views_api.py
+++ b/views_api.py
@@ -12,7 +12,6 @@ from .crud import (
     delete_card,
     enable_disable_card,
     get_card,
-    get_card_by_uid,
     get_cards,
     get_hits,
     get_refunds,
@@ -82,12 +81,6 @@ async def api_card_update(
         raise HTTPException(
             detail="Not your card.", status_code=HTTPStatus.FORBIDDEN
         )
-    checkUid = await get_card_by_uid(data.uid)
-    if checkUid and checkUid.id != card_id:
-        raise HTTPException(
-            detail="UID already registered. Delete registered card and try again.",
-            status_code=HTTPStatus.BAD_REQUEST,
-        )
     card = await update_card(card_id, **data.dict())
     assert card, "update_card should always return a card"
     return card
@@ -102,12 +95,6 @@ async def api_card_create(
     data: CreateCardData,
     wallet: WalletTypeInfo = Depends(require_admin_key),
 ) -> Card:
-    checkUid = await get_card_by_uid(data.uid)
-    if checkUid:
-        raise HTTPException(
-            detail="UID already registered. Delete registered card and try again.",
-            status_code=HTTPStatus.BAD_REQUEST,
-        )
     card = await create_card(wallet_id=wallet.wallet.id, data=data)
     assert card, "create_card should always return a card"
     return card


### PR DESCRIPTION
The card UID is not so important to be UNIQUE in the database. The reason I created this PR is because this is completely useless and sometimes uses delete their card (and its keys) because of this check. Then they're not able to rewrite the card because they deleted the keys. Ofc they can wipe the card and then pair it again but.. this is not the reality.

Also it (kind of) fixes #3  , orphaned cards that are not able to pair if the wallet is deleted because this cannot happen again. It would be better to fix the #3 as suggested in #3 by cascade delete of the bolt cards but this is not the main purpose of this PR.