### PR TITLE
fix(security): Use `crypto.getRandomValues` instead of `Math.random`

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -294,9 +294,8 @@ new Vue({
     generateKeys: function () {
       var self = this
       const genRanHex = size =>
-        [...Array(size)]
-          .map(() => Math.floor(Math.random() * 16).toString(16))
-          .join('')
+        crypto.getRandomValues(new Uint8Array(size / 2))
+          .reduce((acc, i) => acc + ('0' + i.toString(16)).slice(-2), '')
 
       debugcard =
         typeof this.cardDialog.data.card_name === 'string' &&

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -293,8 +293,8 @@ new Vue({
     },
     generateKeys: function () {
       var self = this
-      const genRanHex = size =>
-        crypto.getRandomValues(new Uint8Array(size / 2))
+      const genRandomHexBytes = size =>
+        crypto.getRandomValues(new Uint8Array(size))
           .reduce((acc, i) => acc + ('0' + i.toString(16)).slice(-2), '')
 
       debugcard =
@@ -303,15 +303,15 @@ new Vue({
 
       self.cardDialog.data.k0 = debugcard
         ? '11111111111111111111111111111111'
-        : genRanHex(32)
+        : genRandomHexBytes(16)
 
       self.cardDialog.data.k1 = debugcard
         ? '22222222222222222222222222222222'
-        : genRanHex(32)
+        : genRandomHexBytes(16)
 
       self.cardDialog.data.k2 = debugcard
         ? '33333333333333333333333333333333'
-        : genRanHex(32)
+        : genRandomHexBytes(16)
     },
     closeFormDialog: function () {
       this.cardDialog.data = {}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -295,7 +295,7 @@ new Vue({
       var self = this
       const genRandomHexBytes = size =>
         crypto.getRandomValues(new Uint8Array(size))
-          .reduce((acc, i) => acc + ('0' + i.toString(16)).slice(-2), '')
+          .reduce((acc, i) => acc + i.toString(16).padStart(2, '0'), '')
 
       debugcard =
         typeof this.cardDialog.data.card_name === 'string' &&


### PR DESCRIPTION
`Math.random` should not be used for cryptographic purposes.

I would recommend reflashing/re-initializing all BoltCards generated using the `Math.random()` implementation to avoid them being compromised in the future.