### PR TITLE
fix: failed payments no longer count towards the daily limit

### DIFF
--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -139,7 +139,21 @@ async def lnurl_callback(
     card = await get_card(hit.card_id)
     if not card:
         return LnurlErrorResponse(reason="Card not found.")
-    hit = await spend_hit(card_id=hit.id, amount=int(invoice.amount_msat / 1000))
+
+    amount_sat = int(invoice.amount_msat / 1000)
+    # Validate limits before the hit is marked as spent, so a rejected
+    # attempt does not count towards the daily limit.
+    if amount_sat > int(card.tx_limit):
+        return LnurlErrorResponse(
+            reason=f"Payment failed - Invoice amount {amount_sat} sats is "
+            f"too high. Max allowed: {int(card.tx_limit)} sats."
+        )
+    todays_hits = await get_hits_today(card.id)
+    spent_today = sum(h.amount for h in todays_hits)
+    if spent_today + amount_sat > int(card.daily_limit):
+        return LnurlErrorResponse(reason="Max daily limit spent.")
+
+    hit = await spend_hit(card_id=hit.id, amount=amount_sat)
     if not hit:
         return LnurlErrorResponse(reason="Failed to update hit as spent.")
     try:
@@ -151,6 +165,10 @@ async def lnurl_callback(
         )
         return LnurlSuccessResponse()
     except Exception as exc:
+        # No payment happened — zero the hit amount so the failed attempt
+        # does not count towards the daily limit. The hit stays spent so
+        # the same k1 cannot be claimed again.
+        await spend_hit(card_id=hit.id, amount=0)
         return LnurlErrorResponse(reason=f"Payment failed - {exc}")
 
 


### PR DESCRIPTION
## Problem

In `lnurl_callback` the hit is marked as spent with the full invoice amount **before** `pay_invoice` is attempted. When the payment then fails (e.g. the invoice amount exceeds `tx_limit`, so `pay_invoice` raises), the amount stays recorded in the hit.

On the next tap, `api_scan` sums all of today's hits — including failed ones — and rejects the card with `LNURLW error: Max daily limit spent.` even though no payment ever happened. A single over-limit attempt can lock the card for the rest of the day.

## Changes

- **Validate the invoice amount against `tx_limit` before marking the hit as spent.** A rejected attempt no longer consumes the daily limit. The error message keeps the existing `Payment failed - Invoice amount ... too high. Max allowed: ...` format.
- **Enforce the daily limit in the callback.** The scan-time check runs before the amount is known, so a single payment could previously exceed the daily limit. The callback now checks `spent_today + amount > daily_limit`.
- **Roll back the amount when `pay_invoice` raises.** The hit amount is reset to 0 so the failed attempt doesn't count towards the daily limit. The hit stays `spent`, so the same `k1` cannot be claimed again.

## Testing

Reproduced and verified on an LNbits instance with a physical Bolt Card on a PoS terminal:
- Invoice above `tx_limit` → rejected with the expected error, card keeps working on the next tap (previously: blocked with "Max daily limit spent.")
- Invoice within limits → payment succeeds as before
```